### PR TITLE
Bump `highlight-dark` colors.css dep to 3.0.0

### DIFF
--- a/modules/highlight-dark/index.css
+++ b/modules/highlight-dark/index.css
@@ -1,6 +1,6 @@
 /* Basscss Highlight */
 
-@import "colors.css/myth/variables";
+@import "colors.css/src/_variables.css";
 
 .highlight-dark .hljs {
   color: white;

--- a/modules/highlight-dark/package.json
+++ b/modules/highlight-dark/package.json
@@ -6,7 +6,7 @@
     "prepublish": "mkdir -p css && postcss index.css -u postcss-import -u postcss-custom-media -u postcss-custom-properties -u postcss-remove-root -u autoprefixer -o css/highlight-dark.css"
   },
   "dependencies": {
-    "colors.css": "^2.3.0"
+    "colors.css": "^3.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.1",


### PR DESCRIPTION
`highlight-dark` module was still using v2.3.0 of colors.css.
